### PR TITLE
Escaping modelName for a valid PHP variable name

### DIFF
--- a/src/Sp/FixtureDumper/Generator/ClassFixtureGenerator.php
+++ b/src/Sp/FixtureDumper/Generator/ClassFixtureGenerator.php
@@ -91,7 +91,10 @@ class ClassFixtureGenerator extends AbstractGenerator
         $class->setMethod($method);
 
         foreach ($data as $modelName => $modelData) {
-            $this->generateModel($modelName, $modelData, $metadata, $writer);
+            $search = array(' ', '-', 'á', 'é', 'í', 'ó', 'ú', 'ñ');
+            $replace = array('_', '_', 'a', 'e', 'i', 'o', 'u', 'n');
+            $withoutSpace = str_replace($search, $replace, $modelName);            
+            $this->generateModel($withoutSpace, $modelData, $metadata, $writer);
             $writer->writeln("");
         }
 


### PR DESCRIPTION
When you have a object in database whose ID is a string, and it includes spaces, dashes or accentuated letters, the generated PHP is not valid.
Here is a first approximation for removing the non-valid characters.
