### PR TITLE
added check for MappedSuperclass

### DIFF
--- a/src/Sp/FixtureDumper/ORMDumper.php
+++ b/src/Sp/FixtureDumper/ORMDumper.php
@@ -22,7 +22,7 @@ class ORMDumper extends AbstractDumper
     {
         $calc = new CommitOrderCalculator();
         foreach ($classes as $class) {
-            if (!$class->getReflectionClass()->isInstantiable()) {
+            if (!$class->getReflectionClass()->isInstantiable() || $class->isMappedSuperclass) {
                 continue;
             }
 


### PR DESCRIPTION
As for me, I have entity User (with BaseUser from FOSUserBundle) with table name 'fos_user', but when Doctrine execute query I have error:

check the manual that corresponds to your MySQL server version for the right syntax to use near 'user t0' 

Why? I guess, If we have extended entites (from MappedSuperclass, i.e. BaseUser form FOSUserBundle) we have instance ClassMetadata of this entity and instance ClassMetadata of this MappedSuperclass. And we created query for both instances, but we need query for 'our' entity not for MappedSuperclass.
